### PR TITLE
Potential fix for code scanning alert no. 45: Clear text storage of sensitive information

### DIFF
--- a/geointel_ui_template/index.html
+++ b/geointel_ui_template/index.html
@@ -844,8 +844,10 @@
         }
 
         // ── API Key & Model ──
-        function getStoredApiKey() { return sessionStorage.getItem(STORAGE_KEYS.API_KEY); }
-        function storeApiKey(key) { sessionStorage.setItem(STORAGE_KEYS.API_KEY, key); updateApiKeyIndicator(); }
+        // Store API key only in memory to avoid clear-text persistence in web storage.
+        let inMemoryApiKey = null;
+        function getStoredApiKey() { return inMemoryApiKey; }
+        function storeApiKey(key) { inMemoryApiKey = key; updateApiKeyIndicator(); }
         function getSelectedModel() { return localStorage.getItem(STORAGE_KEYS.MODEL) || 'gemini-3-flash-preview'; }
         function storeModel(model) { localStorage.setItem(STORAGE_KEYS.MODEL, model); }
 


### PR DESCRIPTION
Potential fix for [https://github.com/atiilla/GeoIntel/security/code-scanning/45](https://github.com/atiilla/GeoIntel/security/code-scanning/45)

General approach: avoid persisting the raw API key in browser storage. If we can’t introduce a secure encryption key distinct from the API key itself, client‑side encryption would be effectively security‑through‑obscurity. The safest change, without adding a backend, is to keep the API key only in memory for the lifetime of the page and stop writing it to `sessionStorage`. We can still store the selected model in `localStorage` because that’s not sensitive.

Concrete fix:

- Introduce an in‑memory variable (e.g. `let inMemoryApiKey = null;`) to hold the current key.
- Change `getStoredApiKey` and `storeApiKey` so they no longer touch `sessionStorage`. Instead:
  - `storeApiKey(key)` assigns to `inMemoryApiKey` and updates indicators.
  - `getStoredApiKey()` just returns `inMemoryApiKey`.
- Remove any direct use of `sessionStorage.setItem` / `.getItem` for the API key.
- Keep the rest of the behavior intact: the API key is still loaded from the input, stored for use by other functions via `getStoredApiKey`, and the UI indicator logic remains the same.
- The initialization on `window.load` that calls `updateApiKeyIndicator()` and conditionally opens the modal will still work, but now `getStoredApiKey()` returns a value only after the user has entered a key in this session (which is desirable).

All changes are contained in `geointel_ui_template/index.html` within the shown script section, around the API key helper functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
