### PR TITLE
Potential fix for code scanning alert no. 35: Information exposure through an exception

### DIFF
--- a/geointel/geointel.py
+++ b/geointel/geointel.py
@@ -44,16 +44,18 @@ class GeoIntel:
             return result
 
         except GeoIntelError as e:
+            # Log detailed error on the server, but avoid exposing internal messages to clients
             error_msg = f"{type(e).__name__}: {str(e)}"
             logger.error(error_msg)
             return {
-                "error": str(e),
+                "error": "GeoIntel processing error",
                 "details": type(e).__name__
             }
         except Exception as e:
+            # Log unexpected errors with full stack trace, but return a generic message to clients
             error_msg = f"Unexpected error: {str(e)}"
             logger.error(error_msg, exc_info=True)
             return {
                 "error": "An unexpected error occurred",
-                "details": str(e)
+                "details": "Internal processing error"
             }


### PR DESCRIPTION
Potential fix for [https://github.com/atiilla/GeoIntel/security/code-scanning/35](https://github.com/atiilla/GeoIntel/security/code-scanning/35)

In general, to fix this type of issue you keep detailed exception information on the server (logs) and send only high-level, non-sensitive messages to clients. You avoid returning raw exception messages or stack traces, especially for generic exceptions.

For this codebase, the cleanest fix without changing functionality is:

1. In `geointel/geointel.py`, change the `GeoIntel.locate` error handling so that:
   - For `GeoIntelError`, still distinguish the error type, but do not expose `str(e)` directly; instead send a stable, generic message while logging the detailed exception.
   - For generic `Exception`, do not return `str(e)` to the caller; instead return a generic “unexpected error” message, possibly with a non-sensitive `details` field like a static string or error code.
2. In `geointel/web_server.py`, keep the existing `analyze_image` logic, but when `'error' in result`, ensure that the data from `locate` no longer contains raw exception text, so returning it is safe. No structural change is needed in `analyze_image` once `locate` is sanitized.

Concretely:

- In `GeoIntel.locate`, update the two `except` blocks:
  - Keep logging with full details (`logger.error(..., exc_info=True)`).
  - Return dicts with:
    - `"error"`: a generic message (for example `"GeoIntel processing error"` or `"An unexpected error occurred"`).
    - `"details"`: for `GeoIntelError`, a non-sensitive identifier such as `type(e).__name__`; for generic exceptions, a generic string like `"Internal processing error"` instead of `str(e)`.

No changes are needed to imports, and no new methods or external libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
