### PR TITLE
Potential fix for code scanning alert no. 46: Information exposure through an exception

### DIFF
--- a/geointel/web_server.py
+++ b/geointel/web_server.py
@@ -176,7 +176,8 @@ def analyze_image():
     except GeoIntelError as e:
         logger.error(f"GeoIntel error: {e}")
         return jsonify({
-            'error': str(e)
+            'error': 'GeoIntel processing error',
+            'details': 'A problem occurred while processing your request. Please check your input and try again.'
         }), 400
 
     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/atiilla/GeoIntel/security/code-scanning/46](https://github.com/atiilla/GeoIntel/security/code-scanning/46)

In general, to fix information exposure via exceptions, log detailed exception messages and stack traces only on the server, and return generic, non-sensitive error messages to the client. Avoid including `str(e)` or other raw exception data in HTTP responses.

In this file, the problematic behavior is in the `except GeoIntelError as e:` block of the `/api/analyze` route (lines 176–180). The fix is to stop returning `str(e)` directly and instead (a) log `e` on the server and (b) send a generic, user-safe error message in the JSON response. The unexpected-exception handler directly below (lines 182–187) already follows this pattern and can serve as a template.

Concretely, in `geointel/web_server.py`, within the `analyze_image` function, adjust lines 176–180 so that:

- We continue to log the error with `logger.error(f"GeoIntel error: {e}")` (or similar).
- The JSON response uses a generic error string such as `'GeoIntel processing error'` or similar, and does not interpolate `e` at all.
- Optionally, we can still reflect some non-sensitive information (for example, a generic explanatory `details` string), but not the exception message itself.

No new imports or helper methods are strictly required; we can implement the fix with the existing `logger` and Flask `jsonify`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
